### PR TITLE
Feature/r4 delete joke

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2410,7 +2410,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",

--- a/public/script.js
+++ b/public/script.js
@@ -201,3 +201,22 @@ async function updateJoke(id) {
         }
     }
 }
+
+async function deleteJoke(id) {
+    if (confirm("¿Está seguro de que desea eliminar este chiste?")) {
+        try {
+            const response = await fetch(`/api/jokes/${id}`, {
+                method: 'DELETE',
+            });
+            if (response.ok) {
+                alert('Chiste eliminado correctamente');
+                document.getElementById('searchedJokeContainer').innerHTML = '';
+                document.getElementById('jokeIdInput').value = '';
+            } else {
+                throw new Error('Error al eliminar el chiste');
+            }
+        } catch (error) {
+            alert(error.message);
+        }
+    }
+}

--- a/server.js
+++ b/server.js
@@ -61,6 +61,19 @@ app.put('/api/jokes/:id', async (req, res) => {
     }
 });
 
+//Requerimiento 4
+app.delete('/api/jokes/:id', async (req, res) => {
+    try {
+        const joke = await Joke.findByIdAndDelete(req.params.id);
+        if (!joke) {
+            return res.status(404).json({ message: "Chiste no encontrado" });
+        }
+        res.json({ message: "Chiste eliminado" });
+    } catch (error) {
+        res.status(500).json({ message: "Error al eliminar el chiste" });
+    }
+});
+
 // Ruta para servir el archivo index.html
 app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,25 @@ app.put('/api/jokes/:id', async (req, res) => {
   }
 });
 
+app.delete('/api/jokes/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(404).json({ message: "Chiste no encontrado" });
+    }
+
+    const joke = await Joke.findByIdAndDelete(id);
+    if (!joke) {
+      return res.status(404).json({ message: "Chiste no encontrado" });
+    }
+    res.json({ message: "Chiste eliminado" });
+  } catch (error) {
+    console.error('Error al eliminar el chiste:', error);
+    res.status(500).json({ message: "Error al eliminar el chiste", error: (error as Error).message });
+  }
+});
+
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -47,7 +47,7 @@ paths:
                 id: "60d5ecb74f7e3d3c9c9f5b1e"
         '400':
           description: Error al crear el chiste
-###Requerimiento 3
+### Requerimiento 3
   /api/jokes/{id}:
     put:
       summary: Actualizar un chiste existente

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -104,3 +104,30 @@ paths:
           description: Error al actualizar el chiste
         '404':
           description: Chiste no encontrado
+### Requerimiento 4    
+    delete:
+      summary: Eliminar un chiste
+      description: Este endpoint permite eliminar un chiste existente por su ID.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: ID único del chiste a eliminar
+      responses:
+        '200':
+          description: Chiste eliminado exitosamente
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "Chiste eliminado"
+        '404':
+          description: Chiste no encontrado
+        '500':
+          description: Error al eliminar el chiste

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -104,3 +104,31 @@ describe('PUT /api/jokes/:id', () => {
     expect(response.status).toBe(404);
   });
 });
+
+describe('DELETE /api/jokes/:id', () => {
+  it('should delete an existing joke', async () => {
+    const joke = new Joke({
+      text: 'Joke to be deleted',
+      author: 'Soon to be gone',
+      rating: 3,
+      category: 'Malo'
+    });
+    await joke.save();
+
+    const response = await request(app)
+      .delete(`/api/jokes/${joke._id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Chiste eliminado");
+
+    const deletedJoke = await Joke.findById(joke._id);
+    expect(deletedJoke).toBeNull();
+  });
+
+  it('should return 404 if joke not found', async () => {
+    const response = await request(app)
+      .delete('/api/jokes/nonexistentid');
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   mongoServer = await MongoMemoryServer.create();
   const mongoUri = mongoServer.getUri();
   await mongoose.connect(mongoUri);
-}, 10000); // Aumentamos el tiempo de espera a 10 segundos
+}, 60000); // Aumentamos el tiempo de espera a 60 segundos
 
 afterAll(async () => {
   await mongoose.disconnect();


### PR DESCRIPTION
This pull request introduces the functionality to delete jokes from the system, including the necessary backend API endpoints, frontend integration, and associated tests.

### Backend Changes:
* Added a new endpoint to handle DELETE requests for jokes by ID in `server.js`. This includes error handling for cases where the joke is not found or there is a server error.
* Implemented the DELETE endpoint in `src/index.ts` with additional validation to check if the provided ID is a valid MongoDB ObjectId.

### Frontend Changes:
* Added a new `deleteJoke` function in `public/script.js` to send DELETE requests to the backend and handle the response, including user confirmation and error alerts.

### Documentation Changes:
* Updated `swagger.yaml` to include the new DELETE endpoint for jokes, detailing the parameters, responses, and example outputs.

### Testing Changes:
* Extended the test suite in `tests/index.test.ts` to include tests for the DELETE endpoint, ensuring proper functionality and error handling.
* Increased the timeout for the `beforeAll` hook in `tests/index.test.ts` to accommodate longer setup times.