### PR TITLE
Feature/R5 get joke by ID

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,6 +74,29 @@ app.delete('/api/jokes/:id', async (req, res) => {
     }
 });
 
+//Requerimiento 5
+app.get('/api/jokes/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        // Validar si el ID es un ObjectId válido
+        if (!mongoose.Types.ObjectId.isValid(id)) {
+            console.log("ID inválido:", id); // Log para depuración
+            return res.status(400).json({ message: "ID inválido" });
+        }
+
+        const joke = await Joke.findById(id);
+        if (!joke) {
+            console.log("Chiste no encontrado:", id); // Log para depuración
+            return res.status(404).json({ message: "Chiste no encontrado" });
+        }
+        res.json(joke);
+    } catch (error) {
+        console.log("Error al obtener el chiste:", error); // Log para depuración
+        res.status(500).json({ message: "Error al obtener el chiste" });
+    }
+});
+
 // Ruta para servir el archivo index.html
 app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));

--- a/server.js
+++ b/server.js
@@ -74,28 +74,25 @@ app.delete('/api/jokes/:id', async (req, res) => {
     }
 });
 
-//Requerimiento 5
 app.get('/api/jokes/:id', async (req, res) => {
     try {
         const { id } = req.params;
 
         // Validar si el ID es un ObjectId válido
         if (!mongoose.Types.ObjectId.isValid(id)) {
-            console.log("ID inválido:", id); // Log para depuración
             return res.status(400).json({ message: "ID inválido" });
         }
 
         const joke = await Joke.findById(id);
         if (!joke) {
-            console.log("Chiste no encontrado:", id); // Log para depuración
             return res.status(404).json({ message: "Chiste no encontrado" });
         }
         res.json(joke);
     } catch (error) {
-        console.log("Error al obtener el chiste:", error); // Log para depuración
         res.status(500).json({ message: "Error al obtener el chiste" });
     }
 });
+
 
 // Ruta para servir el archivo index.html
 app.get('/', (req, res) => {
@@ -104,6 +101,4 @@ app.get('/', (req, res) => {
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-    console.log(`Servidor corriendo en el puerto ${PORT}`);
-    console.log(`Visita http://localhost:${PORT} para acceder a la aplicación`);
-});
+    console.log(`Servidor corriendo en el puerto ${PORT}`);    console.log(`Visita http://localhost:${PORT} para acceder a la aplicación`);});

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,22 @@ app.delete('/api/jokes/:id', async (req, res) => {
   }
 });
 
+app.get('/api/jokes/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: "ID inválido" });
+    }
+    const joke = await Joke.findById(id);
+    if (!joke) {
+      return res.status(404).json({ message: "Chiste no encontrado" });
+    }
+    res.json(joke);
+  } catch (error) {
+    res.status(500).json({ message: "Error al obtener el chiste" });
+  }
+});
+
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -131,3 +131,41 @@ paths:
           description: Chiste no encontrado
         '500':
           description: Error al eliminar el chiste
+### Requerimiento 5
+    get:
+      summary: Obtener un chiste por ID
+      description: Este endpoint permite obtener un chiste existente por su ID. Si el chiste no se encuentra, retorna un error.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: ID único del chiste a obtener
+      responses:
+        '200':
+          description: Chiste obtenido exitosamente
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                  author:
+                    type: string
+                  rating:
+                    type: number
+                  category:
+                    type: string
+              example:
+                text: "Hola"
+                author: "a"
+                rating: 5
+                category: "Dad joke"
+        '400':
+          description: ID inválido
+        '404':
+          description: Chiste no encontrado
+        '500':
+          description: Error al obtener el chiste

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -145,19 +145,26 @@ describe('GET /api/jokes/:id', () => {
     });
     await joke.save();
 
+    console.log("Joke ID:", joke._id); // Log para depuración
+
     const response = await request(app).get(`/api/jokes/${joke._id}`);
+    console.log("Response body:", response.body); // Log para depuración
     expect(response.status).toBe(200);
     expect(response.body.text).toBe('Joke to be fetched');
   });
 
   it('should return 404 if joke not found', async () => {
     const nonExistentId = new mongoose.Types.ObjectId();
+    console.log("Non-existent ID:", nonExistentId); // Log para depuración
+
     const response = await request(app).get(`/api/jokes/${nonExistentId}`);
+    console.log("Response status:", response.status); // Log para depuración
     expect(response.status).toBe(404);
   });
 
   it('should return 400 if id is invalid', async () => {
     const response = await request(app).get('/api/jokes/invalidid');
+    console.log("Response status:", response.status); // Log para depuración
     expect(response.status).toBe(400);
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -132,3 +132,32 @@ describe('DELETE /api/jokes/:id', () => {
     expect(response.status).toBe(404);
   });
 });
+
+/* TEST REQUERIMIENTO 5 GET JOKE BY ID */
+
+describe('GET /api/jokes/:id', () => {
+  it('should return a joke by its ID', async () => {
+    const joke = new Joke({
+      text: 'Joke to be fetched',
+      author: 'Author',
+      rating: 4,
+      category: 'Category'
+    });
+    await joke.save();
+
+    const response = await request(app).get(`/api/jokes/${joke._id}`);
+    expect(response.status).toBe(200);
+    expect(response.body.text).toBe('Joke to be fetched');
+  });
+
+  it('should return 404 if joke not found', async () => {
+    const nonExistentId = new mongoose.Types.ObjectId();
+    const response = await request(app).get(`/api/jokes/${nonExistentId}`);
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 400 if id is invalid', async () => {
+    const response = await request(app).get('/api/jokes/invalidid');
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
This pull request introduces a new feature to retrieve a joke by its ID from the API. The changes include adding a new endpoint, updating the API documentation, and creating tests for the new functionality.

### New Feature: Retrieve Joke by ID

* `server.js` and `src/index.ts`: Added a new `GET /api/jokes/:id` endpoint to fetch a joke by its ID, including validation for the ID and appropriate error handling. [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fR77-R104) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R90-R105)

### API Documentation Update

* [`swagger.yaml`](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R134-R171): Updated the API documentation to include the new `GET /api/jokes/:id` endpoint, detailing the request parameters and possible responses.

### Testing

* [`tests/index.test.ts`](diffhunk://#diff-cece62ae24396a5d51e8f2a2cb3abba900652084488023f4de9669eaaf6f81e8R135-R170): Added new tests for the `GET /api/jokes/:id` endpoint to ensure it returns the correct joke, handles non-existent IDs, and manages invalid IDs properly.