### PR TITLE
Feature/r6 joke category count

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,6 +74,29 @@ app.delete('/api/jokes/:id', async (req, res) => {
     }
 });
 
+//Requerimiento 5
+app.get('/api/jokes/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        // Validar si el ID es un ObjectId válido
+        if (!mongoose.Types.ObjectId.isValid(id)) {
+            console.log("ID inválido:", id); // Log para depuración
+            return res.status(400).json({ message: "ID inválido" });
+        }
+
+        const joke = await Joke.findById(id);
+        if (!joke) {
+            console.log("Chiste no encontrado:", id); // Log para depuración
+            return res.status(404).json({ message: "Chiste no encontrado" });
+        }
+        res.json(joke);
+    } catch (error) {
+        console.log("Error al obtener el chiste:", error); // Log para depuración
+        res.status(500).json({ message: "Error al obtener el chiste" });
+    }
+});
+
 // Ruta para servir el archivo index.html
 app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));

--- a/server.js
+++ b/server.js
@@ -93,6 +93,18 @@ app.get('/api/jokes/:id', async (req, res) => {
     }
 });
 
+app.get('/api/jokes/category/:category', async (req, res) => {
+    try {
+        const { category } = req.params;
+        const count = await Joke.countDocuments({ category });
+        if (count === 0) {
+            return res.status(404).json({ message: 'No jokes found in this category' });
+        }
+        res.json({ count });
+    } catch (error) {
+        res.status(500).json({ message: 'Error al obtener la cantidad de chistes' });
+    }
+});
 
 // Ruta para servir el archivo index.html
 app.get('/', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -74,28 +74,25 @@ app.delete('/api/jokes/:id', async (req, res) => {
     }
 });
 
-//Requerimiento 5
 app.get('/api/jokes/:id', async (req, res) => {
     try {
         const { id } = req.params;
 
         // Validar si el ID es un ObjectId válido
         if (!mongoose.Types.ObjectId.isValid(id)) {
-            console.log("ID inválido:", id); // Log para depuración
             return res.status(400).json({ message: "ID inválido" });
         }
 
         const joke = await Joke.findById(id);
         if (!joke) {
-            console.log("Chiste no encontrado:", id); // Log para depuración
             return res.status(404).json({ message: "Chiste no encontrado" });
         }
         res.json(joke);
     } catch (error) {
-        console.log("Error al obtener el chiste:", error); // Log para depuración
         res.status(500).json({ message: "Error al obtener el chiste" });
     }
 });
+
 
 // Ruta para servir el archivo index.html
 app.get('/', (req, res) => {
@@ -104,6 +101,4 @@ app.get('/', (req, res) => {
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-    console.log(`Servidor corriendo en el puerto ${PORT}`);
-    console.log(`Visita http://localhost:${PORT} para acceder a la aplicación`);
-});
+    console.log(`Servidor corriendo en el puerto ${PORT}`);    console.log(`Visita http://localhost:${PORT} para acceder a la aplicación`);});

--- a/server.js
+++ b/server.js
@@ -96,13 +96,17 @@ app.get('/api/jokes/:id', async (req, res) => {
 app.get('/api/jokes/category/:category', async (req, res) => {
     try {
         const { category } = req.params;
+        if (!category) {
+            return res.status(400).json({ message: 'Categoría es requerida' });
+        }
         const count = await Joke.countDocuments({ category });
         if (count === 0) {
             return res.status(404).json({ message: 'No jokes found in this category' });
         }
         res.json({ count });
     } catch (error) {
-        res.status(500).json({ message: 'Error al obtener la cantidad de chistes' });
+        console.error('Error al obtener la cantidad de chistes:', error);
+        res.status(500).json({ message: 'Error al obtener la cantidad de chistes', error: error.message });
     }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,13 +106,17 @@ app.get('/api/jokes/:id', async (req, res) => {
 app.get('/api/jokes/category/:category', async (req, res) => {
   try {
     const { category } = req.params;
+    if (!category) {
+      return res.status(400).json({ message: 'Categoría es requerida' });
+    }
     const count = await Joke.countDocuments({ category });
     if (count === 0) {
       return res.status(404).json({ message: 'No jokes found in this category' });
     }
     res.json({ count });
   } catch (error) {
-    res.status(500).json({ message: 'Error al obtener la cantidad de chistes' });
+    console.error('Error al obtener la cantidad de chistes:', error);
+    res.status(500).json({ message: 'Error al obtener la cantidad de chistes', error: (error as Error).message });
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,19 @@ app.get('/api/jokes/:id', async (req, res) => {
   }
 });
 
+app.get('/api/jokes/category/:category', async (req, res) => {
+  try {
+    const { category } = req.params;
+    const count = await Joke.countDocuments({ category });
+    if (count === 0) {
+      return res.status(404).json({ message: 'No jokes found in this category' });
+    }
+    res.json({ count });
+  } catch (error) {
+    res.status(500).json({ message: 'Error al obtener la cantidad de chistes' });
+  }
+});
+
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,22 @@ app.delete('/api/jokes/:id', async (req, res) => {
   }
 });
 
+app.get('/api/jokes/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: "ID inválido" });
+    }
+    const joke = await Joke.findById(id);
+    if (!joke) {
+      return res.status(404).json({ message: "Chiste no encontrado" });
+    }
+    res.json(joke);
+  } catch (error) {
+    res.status(500).json({ message: "Error al obtener el chiste" });
+  }
+});
+
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -169,3 +169,33 @@ paths:
           description: Chiste no encontrado
         '500':
           description: Error al obtener el chiste
+### Requerimiento 6
+  /api/jokes/category/{category}:
+    get:
+      summary: Obtener la cantidad de chistes por categoría
+      description: Este endpoint permite obtener la cantidad de chistes en una categoría específica. Si no se encuentran chistes en esa categoría, retorna un mensaje de error.
+      parameters:
+        - in: path
+          name: category
+          required: true
+          schema:
+            type: string
+          description: Categoría de los chistes a contar
+      responses:
+        '200':
+          description: Cantidad de chistes obtenida exitosamente
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+              example:
+                count: 5
+        '400':
+          description: Categoría es requerida
+        '404':
+          description: No se encontraron chistes en esta categoría
+        '500':
+          description: Error al obtener la cantidad de chistes

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -131,3 +131,41 @@ paths:
           description: Chiste no encontrado
         '500':
           description: Error al eliminar el chiste
+### Requerimiento 5
+    get:
+      summary: Obtener un chiste por ID
+      description: Este endpoint permite obtener un chiste existente por su ID. Si el chiste no se encuentra, retorna un error.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: ID único del chiste a obtener
+      responses:
+        '200':
+          description: Chiste obtenido exitosamente
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                  author:
+                    type: string
+                  rating:
+                    type: number
+                  category:
+                    type: string
+              example:
+                text: "Hola"
+                author: "a"
+                rating: 5
+                category: "Dad joke"
+        '400':
+          description: ID inválido
+        '404':
+          description: Chiste no encontrado
+        '500':
+          description: Error al obtener el chiste

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -145,19 +145,26 @@ describe('GET /api/jokes/:id', () => {
     });
     await joke.save();
 
+    console.log("Joke ID:", joke._id); // Log para depuración
+
     const response = await request(app).get(`/api/jokes/${joke._id}`);
+    console.log("Response body:", response.body); // Log para depuración
     expect(response.status).toBe(200);
     expect(response.body.text).toBe('Joke to be fetched');
   });
 
   it('should return 404 if joke not found', async () => {
     const nonExistentId = new mongoose.Types.ObjectId();
+    console.log("Non-existent ID:", nonExistentId); // Log para depuración
+
     const response = await request(app).get(`/api/jokes/${nonExistentId}`);
+    console.log("Response status:", response.status); // Log para depuración
     expect(response.status).toBe(404);
   });
 
   it('should return 400 if id is invalid', async () => {
     const response = await request(app).get('/api/jokes/invalidid');
+    console.log("Response status:", response.status); // Log para depuración
     expect(response.status).toBe(400);
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -132,3 +132,32 @@ describe('DELETE /api/jokes/:id', () => {
     expect(response.status).toBe(404);
   });
 });
+
+/* TEST REQUERIMIENTO 5 GET JOKE BY ID */
+
+describe('GET /api/jokes/:id', () => {
+  it('should return a joke by its ID', async () => {
+    const joke = new Joke({
+      text: 'Joke to be fetched',
+      author: 'Author',
+      rating: 4,
+      category: 'Category'
+    });
+    await joke.save();
+
+    const response = await request(app).get(`/api/jokes/${joke._id}`);
+    expect(response.status).toBe(200);
+    expect(response.body.text).toBe('Joke to be fetched');
+  });
+
+  it('should return 404 if joke not found', async () => {
+    const nonExistentId = new mongoose.Types.ObjectId();
+    const response = await request(app).get(`/api/jokes/${nonExistentId}`);
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 400 if id is invalid', async () => {
+    const response = await request(app).get('/api/jokes/invalidid');
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -168,3 +168,32 @@ describe('GET /api/jokes/:id', () => {
     expect(response.status).toBe(400);
   });
 });
+
+describe('GET /api/jokes/category/:category', () => {
+  it('should return the count of jokes in a given category', async () => {
+    const joke1 = new Joke({
+      text: 'Joke 1',
+      author: 'Author 1',
+      rating: 4,
+      category: 'Category1'
+    });
+    const joke2 = new Joke({
+      text: 'Joke 2',
+      author: 'Author 2',
+      rating: 5,
+      category: 'Category1'
+    });
+    await joke1.save();
+    await joke2.save();
+
+    const response = await request(app).get('/api/jokes/category/Category1');
+    expect(response.status).toBe(200);
+    expect(response.body.count).toBe(2);
+  });
+
+  it('should return 404 if no jokes are found in the given category', async () => {
+    const response = await request(app).get('/api/jokes/category/NonExistentCategory');
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('No jokes found in this category');
+  });
+});


### PR DESCRIPTION
This pull request introduces new API endpoints to fetch jokes by ID and to get the count of jokes in a specific category. It also includes corresponding updates to the Swagger documentation and adds tests for these new endpoints.

### New API Endpoints:
* Added `GET /api/jokes/:id` endpoint to fetch a joke by its ID, with validation for the ID format and appropriate error handling [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fR77-R120) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R90-R122).
* Added `GET /api/jokes/category/:category` endpoint to get the count of jokes in a specific category, with validation for the category parameter and appropriate error handling [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fR77-R120) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R90-R122).

### Swagger Documentation:
* Updated `swagger.yaml` to document the new `GET /api/jokes/:id` endpoint, including request parameters and possible responses.
* Updated `swagger.yaml` to document the new `GET /api/jokes/category/:category` endpoint, including request parameters and possible responses.

### Tests:
* Added tests for the `GET /api/jokes/:id` endpoint to verify correct functionality, including cases for valid ID, non-existent ID, and invalid ID format.
* Added tests for the `GET /api/jokes/category/:category` endpoint to verify correct functionality, including cases for existing category and non-existent category.