### PR TITLE
Add test for jokes by score endpoint

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -235,3 +235,32 @@ describe('GET /api/jokes/category/:category', () => {
     expect(response.body.message).toBe('No jokes found in this category');
   });
 });
+
+describe('GET /jokes/score/:puntaje', () => {
+  it('should return jokes with the specified score', async () => {
+    const joke1 = new Joke({
+      text: 'Joke 1',
+      author: 'Author 1',
+      rating: 5,
+      category: 'Category1'
+    });
+    const joke2 = new Joke({
+      text: 'Joke 2',
+      author: 'Author 2',
+      rating: 5,
+      category: 'Category1'
+    });
+    await joke1.save();
+    await joke2.save();
+
+    const response = await request(app).get('/jokes/score/5');
+    expect(response.status).toBe(200);
+    expect(response.body.length).toBe(2);
+  });
+
+  it('should return an error message if no jokes are found with the specified score', async () => {
+    const response = await request(app).get('/jokes/score/10');
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('No jokes found with the specified score');
+  });
+});


### PR DESCRIPTION
Add test cases for the endpoint `GET /jokes/score/:puntaje` in `tests/index.test.ts`.

- Add a test case to check if the endpoint returns jokes with the specified score.
- Add a test case to handle the scenario where no jokes are found with the specified score.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jrgil20/TEP_Proyecto_202515-16012_G1/pull/12?shareId=11a1c50f-0260-4795-bf55-e6a3abe186f9).