### PR TITLE
Add endpoint to get jokes by score

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,19 @@ app.get('/joke/:type', async (req, res) => {
   }
 });
 
+app.get('/jokes/score/:puntaje', async (req, res) => {
+  try {
+    const { puntaje } = req.params;
+    const jokes = await Joke.find({ rating: puntaje });
+    if (jokes.length === 0) {
+      return res.status(404).json({ message: 'No jokes found with the specified score' });
+    }
+    res.json(jokes);
+  } catch (error) {
+    res.status(500).json({ message: 'Error al obtener los chistes', error: (error as Error).message });
+  }
+});
+
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -245,3 +245,37 @@ paths:
                     type: string
               example:
                 error: "Error al obtener el chiste"
+### Requerimiento 7
+  /jokes/score/{puntaje}:
+    get:
+      summary: Obtener chistes por puntaje
+      description: Obtiene todos los chistes en la base de datos con un puntaje específico.
+      parameters:
+        - in: path
+          name: puntaje
+          required: true
+          schema:
+            type: integer
+          description: Puntaje de los chistes a obtener
+      responses:
+        '200':
+          description: Lista de chistes obtenida exitosamente
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    text:
+                      type: string
+                    author:
+                      type: string
+                    rating:
+                      type: integer
+                    category:
+                      type: string
+        '404':
+          description: No se encontraron chistes con el puntaje especificado
+        '500':
+          description: Error al obtener los chistes


### PR DESCRIPTION
Use the `Joke` model to find jokes with the specified rating.
* Return the jokes if found, or a 404 status with a message if not.
* Handle errors by returning a 500 status with an error message.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jrgil20/TEP_Proyecto_202515-16012_G1/pull/13?shareId=1a17a318-0a45-4c73-8527-d661ca4b67d8).