### PR TITLE
Feature/r7 get joke by score

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,19 @@ app.get('/joke/:type', async (req, res) => {
   }
 });
 
+app.get('/jokes/score/:puntaje', async (req, res) => {
+  try {
+    const { puntaje } = req.params;
+    const jokes = await Joke.find({ rating: puntaje });
+    if (jokes.length === 0) {
+      return res.status(404).json({ message: 'No jokes found with the specified score' });
+    }
+    res.json(jokes);
+  } catch (error) {
+    res.status(500).json({ message: 'Error al obtener los chistes', error: (error as Error).message });
+  }
+});
+
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -245,3 +245,37 @@ paths:
                     type: string
               example:
                 error: "Error al obtener el chiste"
+### Requerimiento 7
+  /jokes/score/{puntaje}:
+    get:
+      summary: Obtener chistes por puntaje
+      description: Obtiene todos los chistes en la base de datos con un puntaje específico.
+      parameters:
+        - in: path
+          name: puntaje
+          required: true
+          schema:
+            type: integer
+          description: Puntaje de los chistes a obtener
+      responses:
+        '200':
+          description: Lista de chistes obtenida exitosamente
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    text:
+                      type: string
+                    author:
+                      type: string
+                    rating:
+                      type: integer
+                    category:
+                      type: string
+        '404':
+          description: No se encontraron chistes con el puntaje especificado
+        '500':
+          description: Error al obtener los chistes

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -235,3 +235,32 @@ describe('GET /api/jokes/category/:category', () => {
     expect(response.body.message).toBe('No jokes found in this category');
   });
 });
+
+describe('GET /jokes/score/:puntaje', () => {
+  it('should return jokes with the specified score', async () => {
+    const joke1 = new Joke({
+      text: 'Joke 1',
+      author: 'Author 1',
+      rating: 5,
+      category: 'Category1'
+    });
+    const joke2 = new Joke({
+      text: 'Joke 2',
+      author: 'Author 2',
+      rating: 5,
+      category: 'Category1'
+    });
+    await joke1.save();
+    await joke2.save();
+
+    const response = await request(app).get('/jokes/score/5');
+    expect(response.status).toBe(200);
+    expect(response.body.length).toBe(2);
+  });
+
+  it('should return an error message if no jokes are found with the specified score', async () => {
+    const response = await request(app).get('/jokes/score/10');
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('No jokes found with the specified score');
+  });
+});


### PR DESCRIPTION
This pull request introduces a new feature to retrieve jokes based on their score. The main changes include adding a new endpoint to fetch jokes by score, updating the API documentation, and adding corresponding tests.

### New Endpoint for Fetching Jokes by Score:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R155-R167): Added a new route `GET /jokes/score/:puntaje` to fetch jokes based on their rating. This route handles cases where no jokes are found or an error occurs during the fetch.

### API Documentation Update:

* [`swagger.yaml`](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R248-R281): Updated the API documentation to include the new endpoint `/jokes/score/{puntaje}`. This includes details about the endpoint's summary, description, parameters, and possible responses.

### Tests for the New Endpoint:

* [`tests/index.test.ts`](diffhunk://#diff-cece62ae24396a5d51e8f2a2cb3abba900652084488023f4de9669eaaf6f81e8R238-R266): Added tests for the new `GET /jokes/score/:puntaje` endpoint. These tests check for successful retrieval of jokes with a specific score and handle cases where no jokes are found.